### PR TITLE
Fixed build for 3.9.2

### DIFF
--- a/src/as.c
+++ b/src/as.c
@@ -74,7 +74,7 @@ static ssize_t mmas_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int mmas_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void mmas_pci_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER(mmas_irq_handler,irq,dev_id,regs);
 static void mmas_txinit (struct master_iface *iface);
@@ -259,7 +259,7 @@ static DEVICE_ATTR(uid,S_IRUGO,
  * Handle the insertion of a MultiMaster SDI-T.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 mmas_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/asmi.c
+++ b/src/asmi.c
@@ -114,7 +114,7 @@ static ssize_t lsa_store_range (struct device *dev,
 	const char *buf,
 	size_t count);
 static int lsa_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void lsa_pci_remove (struct pci_dev *pdev);
 static int lsa_init_module (void) __init;
 static void lsa_cleanup_module (void) __exit;
@@ -552,7 +552,7 @@ static DEVICE_ATTR(range,S_IRUGO|S_IWUSR,
  * Checks if a PCI device should be handled by this driver.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 lsa_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/dvbm.h
+++ b/src/dvbm.h
@@ -26,6 +26,11 @@
 #ifndef _DVBM_H
 #define _DVBM_H
 
+#ifndef devinit
+#define devinit
+#define devinitdata
+#endif
+
 #include <linux/pci.h> /* pci_dev */
 #include <linux/init.h> /* __devinit */
 
@@ -37,7 +42,7 @@ extern char dvbm_driver_name[];
 
 /* External function prototypes */
 
-int dvbm_pci_probe_generic (struct pci_dev *pdev) __devinit;
+int dvbm_pci_probe_generic (struct pci_dev *pdev); 
 void dvbm_pci_remove_generic (struct pci_dev *pdev);
 int dvbm_register (struct master_dev *card);
 void dvbm_unregister_all (struct master_dev *card);

--- a/src/dvbm_fd.h
+++ b/src/dvbm_fd.h
@@ -124,7 +124,7 @@
 
 /* External function prototypes */
 
-int dvbm_fd_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_fd_pci_probe (struct pci_dev *pdev);
 void dvbm_fd_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_fdu.h
+++ b/src/dvbm_fdu.h
@@ -222,9 +222,9 @@ extern struct master_iface_operations dvbm_fdu_rxops;
 ssize_t dvbm_fdu_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
-int dvbm_fdu_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_txu_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_rxu_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_fdu_pci_probe (struct pci_dev *pdev);
+int dvbm_txu_pci_probe (struct pci_dev *pdev);
+int dvbm_rxu_pci_probe (struct pci_dev *pdev);
 void dvbm_fdu_pci_remove (struct pci_dev *pdev);
 
 #define dvbm_txu_pci_remove(pdev) dvbm_fdu_pci_remove(pdev)

--- a/src/dvbm_lpfd.h
+++ b/src/dvbm_lpfd.h
@@ -162,9 +162,9 @@ ssize_t dvbm_lpfd_store_blackburst_type (struct device *dev,
 ssize_t dvbm_lpfd_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
-int dvbm_lpfd_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_lptxe_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_lprxe_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_lpfd_pci_probe (struct pci_dev *pdev);
+int dvbm_lptxe_pci_probe (struct pci_dev *pdev);
+int dvbm_lprxe_pci_probe (struct pci_dev *pdev);
 void dvbm_lpfd_pci_remove (struct pci_dev *pdev);
 
 #define dvbm_lptxe_pci_remove(pdev) dvbm_lpfd_pci_remove(pdev)

--- a/src/dvbm_lpqo.h
+++ b/src/dvbm_lpqo.h
@@ -97,7 +97,7 @@
 
 /* External function prototypes */
 
-int dvbm_lpqo_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_lpqo_pci_probe (struct pci_dev *pdev);
 void dvbm_lpqo_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_qdual.h
+++ b/src/dvbm_qdual.h
@@ -153,7 +153,7 @@
 #define DVBM_QDUAL_TCSR_MODE_MASK	0x00000003
 
 /* External function prototypes */
-int dvbm_qdual_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_qdual_pci_probe (struct pci_dev *pdev);
 void dvbm_qdual_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_qi.h
+++ b/src/dvbm_qi.h
@@ -125,7 +125,7 @@
 
 /* External function prototypes */
 
-int dvbm_qi_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_qi_pci_probe (struct pci_dev *pdev);
 void dvbm_qi_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_qio.h
+++ b/src/dvbm_qio.h
@@ -175,9 +175,9 @@ ssize_t dvbm_qio_store_blackburst_type (struct device *dev,
 ssize_t dvbm_qio_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
-int dvbm_q3io_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_q3ino_pci_probe (struct pci_dev *pdev) __devinit;
-int dvbm_qo_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_q3io_pci_probe (struct pci_dev *pdev);
+int dvbm_q3ino_pci_probe (struct pci_dev *pdev);
+int dvbm_qo_pci_probe (struct pci_dev *pdev);
 void dvbm_qio_pci_remove (struct pci_dev *pdev);
 
 #define dvbm_q3io_pci_remove(pdev) dvbm_qio_pci_remove(pdev)

--- a/src/dvbm_qlf.h
+++ b/src/dvbm_qlf.h
@@ -109,7 +109,7 @@
 #define DVBM_QLF_CSR_TSCLKSRC_EXT	0x00000001
 
 /* External function prototypes */
-int dvbm_qlf_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_qlf_pci_probe (struct pci_dev *pdev);
 void dvbm_qlf_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_rx.h
+++ b/src/dvbm_rx.h
@@ -91,7 +91,7 @@
 
 /* External function prototypes */
 
-int dvbm_rx_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_rx_pci_probe (struct pci_dev *pdev);
 void dvbm_rx_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbm_tx.h
+++ b/src/dvbm_tx.h
@@ -60,7 +60,7 @@
 
 /* External function prototypes */
 
-int dvbm_tx_pci_probe (struct pci_dev *pdev) __devinit;
+int dvbm_tx_pci_probe (struct pci_dev *pdev);
 void dvbm_tx_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/dvbmaster.c
+++ b/src/dvbmaster.c
@@ -59,8 +59,8 @@
 
 /* Static function prototypes */
 static int dvbm_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
-static void dvbm_pci_remove (struct pci_dev *pdev) __devexit;
+	const struct pci_device_id *id);
+static void dvbm_pci_remove (struct pci_dev *pdev);
 static int dvbm_init_module (void) __init;
 static void dvbm_cleanup_module (void) __exit;
 
@@ -284,7 +284,7 @@ static struct class *dvbm_class;
  * Perform generic PCI device initialization.
  * Returns a negative error code on failure and 0 on success.
  **/
-int __devinit
+int 
 dvbm_pci_probe_generic (struct pci_dev *pdev)
 {
 	int err;
@@ -329,7 +329,7 @@ dvbm_pci_probe_generic (struct pci_dev *pdev)
  * Call the appropriate PCI insertion handler.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 dvbm_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {
@@ -425,7 +425,7 @@ dvbm_pci_remove_generic (struct pci_dev *pdev)
  *
  * Call the appropriate PCI removal handler.
  **/
-static void __devexit
+static void 
 dvbm_pci_remove (struct pci_dev *pdev)
 {
 	switch (pdev->device) {

--- a/src/hdsdim.h
+++ b/src/hdsdim.h
@@ -37,7 +37,7 @@ extern char hdsdim_driver_name[];
 
 /* External function prototypes */
 
-int hdsdim_pci_probe_generic (struct pci_dev *pdev) __devinit;
+int hdsdim_pci_probe_generic (struct pci_dev *pdev);
 void hdsdim_pci_remove_generic (struct pci_dev *pdev);
 int hdsdim_register (struct master_dev *card);
 void hdsdim_unregister_all (struct master_dev *card);

--- a/src/hdsdim_qie.h
+++ b/src/hdsdim_qie.h
@@ -128,7 +128,7 @@
 
 /* External function prototypes */
 
-int hdsdim_qie_pci_probe (struct pci_dev *pdev) __devinit;
+int hdsdim_qie_pci_probe (struct pci_dev *pdev);
 void hdsdim_qie_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/hdsdim_rxe.h
+++ b/src/hdsdim_rxe.h
@@ -133,7 +133,7 @@
 
 /* External function prototypes */
 
-int hdsdim_rxe_pci_probe (struct pci_dev *pdev) __devinit;
+int hdsdim_rxe_pci_probe (struct pci_dev *pdev);
 void hdsdim_rxe_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/hdsdim_txe.h
+++ b/src/hdsdim_txe.h
@@ -139,7 +139,7 @@
 
 /* External function prototypes */
 
-int hdsdim_txe_pci_probe (struct pci_dev *pdev) __devinit;
+int hdsdim_txe_pci_probe (struct pci_dev *pdev);
 void hdsdim_txe_pci_remove (struct pci_dev *pdev);
 
 #endif

--- a/src/hdsdimaster.c
+++ b/src/hdsdimaster.c
@@ -53,8 +53,8 @@
 
 /* Static function prototypes */
 static int hdsdim_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
-static void hdsdim_pci_remove (struct pci_dev *pdev) __devexit;
+	const struct pci_device_id *id); 
+static void hdsdim_pci_remove (struct pci_dev *pdev);
 static int hdsdim_init_module (void) __init;
 static void hdsdim_cleanup_module (void) __exit;
 
@@ -102,7 +102,7 @@ static struct class *hdsdim_class;
  * Perform generic PCI device initialization.
  * Returns a negative error code on failure and 0 on success.
  **/
-int __devinit
+int
 hdsdim_pci_probe_generic (struct pci_dev *pdev)
 {
 	int err;
@@ -151,7 +151,7 @@ hdsdim_pci_probe_generic (struct pci_dev *pdev)
  * Call the appropriate PCI insertion handler.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 hdsdim_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {
@@ -190,7 +190,7 @@ hdsdim_pci_remove_generic (struct pci_dev *pdev)
  *
  * Call the appropriate PCI removal handler.
  **/
-static void __devexit
+static void 
 hdsdim_pci_remove (struct pci_dev *pdev)
 {
 	switch (pdev->device) {

--- a/src/jtag.c
+++ b/src/jtag.c
@@ -115,7 +115,7 @@ static ssize_t lsj_store_range (struct device *dev,
 	const char *buf,
 	size_t count);
 static int lsj_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void lsj_pci_remove (struct pci_dev *pdev);
 static int lsj_init_module (void) __init;
 static void lsj_cleanup_module (void) __exit;
@@ -533,7 +533,7 @@ static DEVICE_ATTR(range,S_IRUGO|S_IWUSR,
  * Checks if a PCI device should be handled by this driver.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 lsj_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/sa.c
+++ b/src/sa.c
@@ -74,7 +74,7 @@ static ssize_t mmsa_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int mmsa_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void mmsa_pci_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER(mmsa_irq_handler,irq,dev_id,regs);
 static void mmsa_txinit (struct master_iface *iface);
@@ -259,7 +259,7 @@ static DEVICE_ATTR(uid,S_IRUGO,
  * Handle the insertion of a MultiMaster SDI-R.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 mmsa_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/sdim_lpfd.c
+++ b/src/sdim_lpfd.c
@@ -72,7 +72,7 @@ static ssize_t sdim_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int sdim_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void sdim_pci_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER(sdim_irq_handler,irq,dev_id,regs);
 static void sdim_txinit (struct master_iface *iface);
@@ -255,7 +255,7 @@ static DEVICE_ATTR(uid,S_IRUGO,
  * Handle the insertion of a SDI Master.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 sdim_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/sdim_qie.c
+++ b/src/sdim_qie.c
@@ -67,7 +67,7 @@ static ssize_t sdim_qie_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int sdim_qie_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void sdim_qie_pci_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER(sdim_qie_irq_handler,irq,dev_id,regs);
 static void sdim_qie_init (struct master_iface *iface);
@@ -162,7 +162,7 @@ static DEVICE_ATTR(uid,S_IRUGO,
  * Handle the insertion of a SDI Master Q/i.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 sdim_qie_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/sdim_qoe.c
+++ b/src/sdim_qoe.c
@@ -72,7 +72,7 @@ static ssize_t sdim_qoe_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int sdim_qoe_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 void sdim_qoe_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER (sdim_qoe_irq_handler, irq, dev_id, regs);
 static void sdim_qoe_init (struct master_iface *iface);
@@ -226,7 +226,7 @@ static DEVICE_ATTR(uid,S_IRUGO, sdim_qoe_show_uid, NULL);
  * Handle the insertion of a SDI Master Q/o.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 sdim_qoe_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {

--- a/src/sdimaster.c
+++ b/src/sdimaster.c
@@ -72,7 +72,7 @@ static ssize_t sdim_show_uid (struct device *dev,
 	struct device_attribute *attr,
 	char *buf);
 static int sdim_pci_probe (struct pci_dev *pdev,
-	const struct pci_device_id *id) __devinit;
+	const struct pci_device_id *id);
 static void sdim_pci_remove (struct pci_dev *pdev);
 static irqreturn_t IRQ_HANDLER(sdim_irq_handler,irq,dev_id,regs);
 static void sdim_txinit (struct master_iface *iface);
@@ -257,7 +257,7 @@ static DEVICE_ATTR(uid,S_IRUGO,
  * Handle the insertion of a SDI Master.
  * Returns a negative error code on failure and 0 on success.
  **/
-static int __devinit
+static int 
 sdim_pci_probe (struct pci_dev *pdev,
 	const struct pci_device_id *id)
 {


### PR DESCRIPTION
Hello KieranK,
  I am using the dveo driver and removed the __devinit and __devexit types that were deprecated during the 3.8 branch.  I did compile successfully against 3.8.13 and 3.9.2.  I am running the driver successfully with 3.9.2. 

Eric
