### PR TITLE
update kernel driver API

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,20 +10,20 @@ dvbm-objs := dvbmaster.o mdev.o \
 	dvbm_fd.o dvbm_fdu.o dvbm_rx.o dvbm_rxu.o dvbm_tx.o dvbm_txu.o \
 	dvbm_lpfd.o dvbm_qlf.o dvbm_qi.o \
 	dvbm_qio.o dvbm_qo.o dvbm_qdual.o dvbm_q3ioe.o dvbm_q3inoe.o \
-	dvbm_lptxe.o dvbm_lprxe.o dvbm_lpqo.o
+	dvbm_lptxe.o dvbm_lprxe.o dvbm_lpqo.o miface.o mdma.o
 ls_as-objs := asmi.o eeprom.o
 ls_jtag-objs := jtag.o eeprom.o
 sdi-objs := sdicore.o miface.o mdma.o
 sdiaudio-objs := sdiaudiocore.o miface.o mdma.o
 sdivideo-objs := sdivideocore.o miface.o mdma.o
-sdim-objs := sdimaster.o mdev.o plx9080.o
-sdilpm-objs := sdim_lpfd.o mdev.o lsdma.o
-sdiqoe-objs := sdim_qoe.o mdev.o lsdma.o
-sdiqie-objs := sdim_qie.o mdev.o plx9080.o lsdma.o
+sdim-objs := sdimaster.o mdev.o plx9080.o miface.o mdma.o
+sdilpm-objs := sdim_lpfd.o mdev.o lsdma.o miface.o mdma.o
+sdiqoe-objs := sdim_qoe.o mdev.o lsdma.o miface.o mdma.o
+sdiqie-objs := sdim_qie.o mdev.o plx9080.o lsdma.o miface.o mdma.o
 hdsdim-objs := hdsdimaster.o mdev.o lsdma.o \
-	hdsdim_qie.o hdsdim_txe.o hdsdim_rxe.o
-mmas-objs := as.o mdev.o plx9080.o
-mmsa-objs := sa.o mdev.o plx9080.o
+	hdsdim_qie.o hdsdim_txe.o hdsdim_rxe.o miface.o mdma.o
+mmas-objs := as.o mdev.o plx9080.o miface.o mdma.o
+mmsa-objs := sa.o mdev.o plx9080.o miface.o mdma.o
 
 else
 

--- a/src/as.c
+++ b/src/as.c
@@ -39,8 +39,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "sdicore.h"

--- a/src/asicore.c
+++ b/src/asicore.c
@@ -121,8 +121,7 @@ static spinlock_t asi_iface_lock;
 #endif
 
 static struct class *asi_class;
-static CLASS_ATTR(version,S_IRUGO,
-	miface_show_version,NULL);
+static CLASS_ATTR_RO(version);
 
 /**
  * asi_open - ASI interface open() method

--- a/src/asicore.c
+++ b/src/asicore.c
@@ -39,8 +39,8 @@
 #include <linux/cdev.h> /* cdev_init () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* test_and_clear_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* test_and_clear_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/asmi.c
+++ b/src/asmi.c
@@ -39,8 +39,8 @@
 #include <linux/device.h> /* class_create () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/io.h> /* readl () */
-#include <asm/uaccess.h> /* put_user () */
+#include <linux/io.h> /* readl () */
+#include <linux/uaccess.h> /* put_user () */
 
 #include "../include/master.h"
 #include "plx9080.h"

--- a/src/dvbm_fd.c
+++ b/src/dvbm_fd.c
@@ -36,8 +36,8 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_fdu.c
+++ b/src/dvbm_fdu.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_lpfd.c
+++ b/src/dvbm_lpfd.c
@@ -37,8 +37,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_lpqo.c
+++ b/src/dvbm_lpqo.c
@@ -37,8 +37,8 @@
 #include <linux/device.h> /* device_create file */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_lprxe.c
+++ b/src/dvbm_lprxe.c
@@ -36,7 +36,7 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_lptxe.c
+++ b/src/dvbm_lptxe.c
@@ -36,7 +36,7 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_q3inoe.c
+++ b/src/dvbm_q3inoe.c
@@ -37,7 +37,7 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_q3ioe.c
+++ b/src/dvbm_q3ioe.c
@@ -37,7 +37,7 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_qdual.c
+++ b/src/dvbm_qdual.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_qi.c
+++ b/src/dvbm_qi.c
@@ -37,8 +37,8 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_qio.c
+++ b/src/dvbm_qio.c
@@ -36,7 +36,7 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_lock () */
 
-#include <asm/uaccess.h> /* put_user () */
+#include <linux/uaccess.h> /* put_user () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_qlf.c
+++ b/src/dvbm_qlf.c
@@ -37,8 +37,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_qo.c
+++ b/src/dvbm_qo.c
@@ -37,7 +37,7 @@
 #include <linux/device.h> /* device_create file */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_rx.c
+++ b/src/dvbm_rx.c
@@ -37,8 +37,8 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_rxu.c
+++ b/src/dvbm_rxu.c
@@ -35,7 +35,7 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_tx.c
+++ b/src/dvbm_tx.c
@@ -38,8 +38,8 @@
 #include <linux/mutex.h> /* mutex_init () */
 #include <linux/delay.h> /* msleep () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/dvbm_txu.c
+++ b/src/dvbm_txu.c
@@ -35,7 +35,7 @@
 #include <linux/interrupt.h> /* irqreturn_t */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "../include/master.h"

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -25,7 +25,7 @@
 #include <linux/sched.h> /* schedule_timeout () */
 #include <linux/delay.h> /* udelay () */
 
-#include <asm/io.h> /* readl () */
+#include <linux/io.h> /* readl () */
 
 #include "plx9080.h"
 #include "eeprom.h"

--- a/src/gt64131.c
+++ b/src/gt64131.c
@@ -28,7 +28,7 @@
 #include <linux/dmapool.h> /* dma_pool_create () */
 #include <linux/errno.h> /* error codes */
 
-#include <asm/uaccess.h> /* copy_to_user () */
+#include <linux/uaccess.h> /* copy_to_user () */
 
 #include "gt64131.h"
 #include "mdma.h"

--- a/src/hdsdim_qie.c
+++ b/src/hdsdim_qie.c
@@ -37,8 +37,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdiaudiocore.h"
 #include "sdivideocore.h"

--- a/src/hdsdim_rxe.c
+++ b/src/hdsdim_rxe.c
@@ -37,8 +37,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdiaudiocore.h"
 #include "sdivideocore.h"

--- a/src/hdsdim_txe.c
+++ b/src/hdsdim_txe.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdivideocore.h"
 #include "sdiaudiocore.h"

--- a/src/jtag.c
+++ b/src/jtag.c
@@ -39,8 +39,8 @@
 #include <linux/device.h> /* class_create () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/io.h> /* readl () */
-#include <asm/uaccess.h> /* put_user () */
+#include <linux/io.h> /* readl () */
+#include <linux/uaccess.h> /* put_user () */
 
 #include "../include/master.h"
 #include "plx9080.h"

--- a/src/lsdma.c
+++ b/src/lsdma.c
@@ -29,7 +29,7 @@
 #include <linux/dmapool.h> /* dma_pool_create () */
 #include <linux/errno.h> /* error codes */
 
-#include <asm/bitops.h> /* clear_bit () */
+#include <linux/bitops.h> /* clear_bit () */
 #include <linux/uaccess.h> /* copy_from_user () */
 
 #include "lsdma.h"

--- a/src/lsdma.c
+++ b/src/lsdma.c
@@ -30,7 +30,7 @@
 #include <linux/errno.h> /* error codes */
 
 #include <asm/bitops.h> /* clear_bit () */
-#include <asm/uaccess.h> /* copy_from_user () */
+#include <linux/uaccess.h> /* copy_from_user () */
 
 #include "lsdma.h"
 #include "mdma.h"

--- a/src/mdev.c
+++ b/src/mdev.c
@@ -36,6 +36,7 @@
 
 #include "../include/master.h"
 #include "mdev.h"
+#include "miface.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,26)
 static inline const char *
@@ -200,8 +201,7 @@ mdev_show_version (struct class *cls,
 	return snprintf (buf, PAGE_SIZE, "%s\n", MASTER_DRIVER_VERSION);
 }
 
-static CLASS_ATTR(version,S_IRUGO,
-	mdev_show_version,NULL);
+static CLASS_ATTR_RO(version);
 
 /**
  * mdev_init - create the device class

--- a/src/mdev.h
+++ b/src/mdev.h
@@ -34,7 +34,7 @@
 #include <linux/mutex.h> /* mutex */
 #include <linux/module.h> 
 
-#include <asm/io.h> /* inl () */
+#include <linux/io.h> /* inl () */
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18))
 typedef unsigned long resource_size_t;

--- a/src/mdma.c
+++ b/src/mdma.c
@@ -30,8 +30,8 @@
 #include <linux/mm_types.h> /* vm_fault_t */
 #include <linux/sched.h> /* struct task_struct */
 
-#include <asm/bitops.h> /* clear_bit () */
-#include <asm/uaccess.h> /* copy_from_user () */
+#include <linux/bitops.h> /* clear_bit () */
+#include <linux/uaccess.h> /* copy_from_user () */
 
 #include "mdma.h"
 

--- a/src/mdma.c
+++ b/src/mdma.c
@@ -27,6 +27,7 @@
 #include <linux/spinlock.h> /* spin_lock_init () */
 #include <linux/errno.h> /* error codes */
 #include <linux/mm.h> /* get_page () */
+#include <linux/sched.h> /* struct task_struct */
 
 #include <asm/bitops.h> /* clear_bit () */
 #include <asm/uaccess.h> /* copy_from_user () */

--- a/src/mdma.c
+++ b/src/mdma.c
@@ -27,6 +27,7 @@
 #include <linux/spinlock.h> /* spin_lock_init () */
 #include <linux/errno.h> /* error codes */
 #include <linux/mm.h> /* get_page () */
+#include <linux/mm_types.h> /* vm_fault_t */
 #include <linux/sched.h> /* struct task_struct */
 
 #include <asm/bitops.h> /* clear_bit () */
@@ -44,9 +45,19 @@ static struct page *mdma_nopage (struct vm_area_struct *vma,
 struct vm_operations_struct mdma_vm_ops = {
 	.nopage = mdma_nopage
 };
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0))
 static int mdma_fault (struct vm_area_struct *vma,
 	struct vm_fault *vmf);
+struct vm_operations_struct mdma_vm_ops = {
+	.fault = mdma_fault
+};
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0))
+static int mdma_fault (struct vm_fault *vmf);
+struct vm_operations_struct mdma_vm_ops = {
+	.fault = mdma_fault
+};
+#else
+static vm_fault_t mdma_fault (struct vm_fault *vmf);
 struct vm_operations_struct mdma_vm_ops = {
 	.fault = mdma_fault
 };
@@ -267,7 +278,7 @@ mdma_nopage (struct vm_area_struct *vma,
 OUT:
 	return pg;
 }
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0))
 /**
  * mdma_fault - page fault handler
  * @vma: VMA
@@ -279,6 +290,46 @@ static int
 mdma_fault (struct vm_area_struct *vma,
 	struct vm_fault *vmf)
 {
+	struct master_dma *dma = vma->vm_private_data;
+
+	if (vmf->pgoff >= dma->pointers_per_buf * dma->buffers) {
+		return VM_FAULT_SIGBUS;
+	}
+	vmf->page = virt_to_page (dma->vpage[vmf->pgoff]);
+	get_page (vmf->page);
+	return 0;
+}
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0))
+/**
+ * mdma_fault - page fault handler
+ * @vmf: vm_fault structure
+ *
+ * Arrange for a missing page to exist and return its address.
+ **/
+static int
+mdma_fault (struct vm_fault *vmf)
+{
+	struct vm_area_struct *vma = vmf->vma;
+	struct master_dma *dma = vma->vm_private_data;
+
+	if (vmf->pgoff >= dma->pointers_per_buf * dma->buffers) {
+		return VM_FAULT_SIGBUS;
+	}
+	vmf->page = virt_to_page (dma->vpage[vmf->pgoff]);
+	get_page (vmf->page);
+	return 0;
+}
+#else
+/**
+ * mdma_fault - page fault handler
+ * @vmf: vm_fault structure
+ *
+ * Arrange for a missing page to exist and return its address.
+ **/
+static vm_fault_t
+mdma_fault (struct vm_fault *vmf)
+{
+	struct vm_area_struct *vma = vmf->vma;
 	struct master_dma *dma = vma->vm_private_data;
 
 	if (vmf->pgoff >= dma->pointers_per_buf * dma->buffers) {

--- a/src/miface.c
+++ b/src/miface.c
@@ -30,6 +30,7 @@
 #include <linux/poll.h> /* poll_wait () */
 #include <linux/dma-mapping.h> /* DMA_FROM_DEVICE */
 #include <linux/mutex.h> /* mutex_lock () */
+#include <linux/cred.h> /* current_uid () */
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,2,0)
 #include <linux/module.h> /* modules */

--- a/src/miface.c
+++ b/src/miface.c
@@ -60,13 +60,13 @@ static const char fmt_u[] = "%u\n";
 static const char fmt_x[] = "0x%04X\n";
 
 /**
- * miface_show_version - class attribute read handler
+ * version_show - class attribute read handler
  * @cls: class being read
  * @attr: class attribute
  * @buf: output buffer
  **/
 ssize_t
-miface_show_version (struct class *cls,
+version_show (struct class *cls,
 	struct class_attribute *attr,
 	char *buf)
 {

--- a/src/miface.h
+++ b/src/miface.h
@@ -169,7 +169,7 @@ struct master_iface {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,34))
 #define miface_show_version(cls,attr,buf) miface_show_version(cls,buf)
 #endif
-ssize_t miface_show_version (struct class *cls,
+ssize_t version_show (struct class *cls,
 	struct class_attribute *attr,
 	char *buf);
 ssize_t miface_show_buffers (struct device *dev,

--- a/src/plx9080.c
+++ b/src/plx9080.c
@@ -31,7 +31,7 @@
 #include <linux/delay.h> /* msleep () */
 
 #include <asm/bitops.h> /* clear_bit () */
-#include <asm/uaccess.h> /* copy_from_user () */
+#include <linux/uaccess.h> /* copy_from_user () */
 
 #include "plx9080.h"
 #include "mdma.h"

--- a/src/plx9080.c
+++ b/src/plx9080.c
@@ -30,7 +30,7 @@
 #include <linux/errno.h> /* error codes */
 #include <linux/delay.h> /* msleep () */
 
-#include <asm/bitops.h> /* clear_bit () */
+#include <linux/bitops.h> /* clear_bit () */
 #include <linux/uaccess.h> /* copy_from_user () */
 
 #include "plx9080.h"

--- a/src/sa.c
+++ b/src/sa.c
@@ -39,8 +39,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "asicore.h"
 #include "sdicore.h"

--- a/src/sdiaudiocore.c
+++ b/src/sdiaudiocore.c
@@ -120,8 +120,7 @@ static spinlock_t sdiaudio_iface_lock;
 #endif
 
 static struct class *sdiaudio_class;
-static CLASS_ATTR(version,S_IRUGO,
-	miface_show_version,NULL);
+static CLASS_ATTR_RO(version);
 
 /**
  * sdiaudio_open - SMPTE 292M and SMPTE 259M-C audio interface open() method

--- a/src/sdiaudiocore.c
+++ b/src/sdiaudiocore.c
@@ -38,8 +38,8 @@
 #include <linux/cdev.h> /* cdev_init () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* test_and_clear_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* test_and_clear_bit () */
 
 #include "sdiaudiocore.h"
 #include "../include/master.h"

--- a/src/sdicore.c
+++ b/src/sdicore.c
@@ -38,8 +38,8 @@
 #include <linux/cdev.h> /* cdev_init () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* test_and_clear_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* test_and_clear_bit () */
 
 #include "sdicore.h"
 #include "../include/master.h"

--- a/src/sdicore.c
+++ b/src/sdicore.c
@@ -110,8 +110,7 @@ static spinlock_t sdi_iface_lock;
 #endif
 
 static struct class *sdi_class;
-static CLASS_ATTR(version,S_IRUGO,
-	miface_show_version,NULL);
+static CLASS_ATTR_RO(version);
 
 /**
  * sdi_open - SDI interface open() method

--- a/src/sdim_lpfd.c
+++ b/src/sdim_lpfd.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdicore.h"
 #include "../include/master.h"

--- a/src/sdim_qie.c
+++ b/src/sdim_qie.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdicore.h"
 #include "../include/master.h"

--- a/src/sdim_qoe.c
+++ b/src/sdim_qoe.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdicore.h"
 #include "../include/master.h"

--- a/src/sdimaster.c
+++ b/src/sdimaster.c
@@ -38,8 +38,8 @@
 #include <linux/device.h> /* device_create_file () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* set_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* set_bit () */
 
 #include "sdicore.h"
 #include "../include/master.h"

--- a/src/sdivideocore.c
+++ b/src/sdivideocore.c
@@ -38,8 +38,8 @@
 #include <linux/cdev.h> /* cdev_init () */
 #include <linux/mutex.h> /* mutex_init () */
 
-#include <asm/uaccess.h> /* put_user () */
-#include <asm/bitops.h> /* test_and_clear_bit () */
+#include <linux/uaccess.h> /* put_user () */
+#include <linux/bitops.h> /* test_and_clear_bit () */
 
 #include "sdivideocore.h"
 #include "../include/master.h"

--- a/src/sdivideocore.c
+++ b/src/sdivideocore.c
@@ -138,8 +138,7 @@ static spinlock_t sdivideo_iface_lock;
 #endif
 
 static struct class *sdivideo_class;
-static CLASS_ATTR(version,S_IRUGO,
-	miface_show_version,NULL);
+static CLASS_ATTR_RO(version);
 
 /**
  * sdivideo_open - SMPTE 292M and SMPTE 259M-C video interface open() method


### PR DESCRIPTION
Completely untested.  Changes mostly to address build failures.  Some warning still exist.

4.4 (Ubuntu 14): `txcfg.c:578:3: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]` in several places

4.11 (Ubuntu 18): same as above

5.4 (Arch linux-lts): `src/dvbm.o(.data+0x40): Section mismatch in reference from the variable dvbm_pci_driver to the function .init.text:dvbm_pci_probe()` in several objects